### PR TITLE
修复tagArticles解析标签中的BUG

### DIFF
--- a/app/portal/service/ApiService.php
+++ b/app/portal/service/ApiService.php
@@ -236,7 +236,7 @@ class ApiService
                 $articles = $articles->paginate(intval($page));
             }
 
-            if (!empty($relation) && !empty($articles['items'])) {
+            if (!empty($relation) && !empty($articles->items())) {
                 $articles->load($relation);
             }
 

--- a/app/portal/taglib/Portal.php
+++ b/app/portal/taglib/Portal.php
@@ -171,8 +171,7 @@ parse;
             }
         }
 
-        if (strpos($tag['order'], '$') === 0) {
-            $order = $tag['order'];
+        if (strpos($order, '$') === 0) {
             $this->autoBuildVar($order);
         } else {
             $order = "'{$order}'";

--- a/app/portal/taglib/Portal.php
+++ b/app/portal/taglib/Portal.php
@@ -21,6 +21,7 @@ class Portal extends TagLib
         // 标签定义： attr 属性列表 close 是否闭合（0 或者1 默认1） alias 标签别名 level 嵌套层次
         'articles'         => ['attr' => 'field,where,limit,order,page,relation,returnVarName,pageVarName,categoryIds', 'close' => 1],//非必须属性item
         'tagarticles'      => ['attr' => 'field,where,limit,order,page,relation,returnVarName,pageVarName,tagId', 'close' => 1],//非必须属性item
+        'page'             => ['attr' => 'id', 'close' => 1],//非必须属性item
         'breadcrumb'       => ['attr' => 'cid', 'close' => 1],//非必须属性self
         'categories'       => ['attr' => 'ids,where,order', 'close' => 1],//非必须属性item
         'category'         => ['attr' => 'id', 'close' => 1],//非必须属性item
@@ -33,10 +34,10 @@ class Portal extends TagLib
      */
     public function tagArticles($tag, $content)
     {
-        $item = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
-        $order = empty($tag['order']) ? 'post.published_time DESC' : $tag['order'];
-        $relation = empty($tag['relation']) ? '' : $tag['relation'];
-        $pageVarName = empty($tag['pageVarName']) ? '__PAGE_VAR_NAME__' : $tag['pageVarName'];
+        $item          = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
+        $order         = empty($tag['order']) ? 'post.published_time DESC' : $tag['order'];
+        $relation      = empty($tag['relation']) ? '' : $tag['relation'];
+        $pageVarName   = empty($tag['pageVarName']) ? '__PAGE_VAR_NAME__' : $tag['pageVarName'];
         $returnVarName = empty($tag['returnVarName']) ? 'articles_data' : $tag['returnVarName'];
 
         $field = "''";
@@ -119,10 +120,10 @@ parse;
      */
     public function tagTagArticles($tag, $content)
     {
-        $item = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
-        $order = empty($tag['order']) ? 'post.published_time DESC' : $tag['order'];
-        $relation = empty($tag['relation']) ? '' : $tag['relation'];
-        $pageVarName = empty($tag['pageVarName']) ? '__PAGE_VAR_NAME__' : $tag['pageVarName'];
+        $item          = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
+        $order         = empty($tag['order']) ? 'post.published_time DESC' : $tag['order'];
+        $relation      = empty($tag['relation']) ? '' : $tag['relation'];
+        $pageVarName   = empty($tag['pageVarName']) ? '__PAGE_VAR_NAME__' : $tag['pageVarName'];
         $returnVarName = empty($tag['returnVarName']) ? 'tag_articles_data' : $tag['returnVarName'];
 
         $field = "''";
@@ -200,6 +201,26 @@ parse;
     }
 
     /**
+     * 单页文章标签
+     */
+    public function tagPage($tag, $content)
+    {
+        $id = empty($tag['id']) ? 0 : $tag['id'];
+        if (strpos($id, '$') === 0) {
+            $this->autoBuildVar($id);
+        }
+        $returnVarName = empty($tag['item']) ? 'portal_page' : $tag['item'];
+
+        $parse = <<<parse
+<?php
+\${$returnVarName} = \app\portal\service\ApiService::page({$id});
+?>
+{$content}
+parse;
+        return $parse;
+    }
+
+    /**
      * 面包屑标签
      */
     public function tagBreadcrumb($tag, $content)
@@ -236,9 +257,9 @@ parse;
      */
     public function tagCategories($tag, $content)
     {
-        $item = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
-        $order = empty($tag['order']) ? '' : $tag['order'];
-        $ids = empty($tag['ids']) ? '""' : $tag['ids'];
+        $item          = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
+        $order         = empty($tag['order']) ? '' : $tag['order'];
+        $ids           = empty($tag['ids']) ? '""' : $tag['ids'];
         $returnVarName = 'portal_categories_data';
         if (strpos($ids, '$') === 0) {
             $this->autoBuildVar($ids);
@@ -272,7 +293,7 @@ parse;
      */
     public function tagCategory($tag, $content)
     {
-        $id = $tag['id'] ?: '';
+        $id = empty($tag['id']) ? 0 : $tag['id'];
         if (strpos($id, '$') === 0) {
             $this->autoBuildVar($id);
         }
@@ -292,7 +313,7 @@ parse;
      */
     public function tagSubCategories($tag, $content)
     {
-        $item = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
+        $item          = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
         $returnVarName = 'portal_sub_categories_data';
 
         $categoryId = "0";
@@ -324,7 +345,7 @@ parse;
      */
     public function tagAllSubCategories($tag, $content)
     {
-        $item = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
+        $item          = empty($tag['item']) ? 'vo' : $tag['item'];//循环变量名
         $returnVarName = 'portal_all_sub_categories_data';
 
         $categoryId = "0";


### PR DESCRIPTION
BUG有两处

1. 标签解析文件Portal.php中，对$order是否为变量的判断(174行)时，如果没有定义order属性，则报出异常。由于该属性在方法开始时已处理过，因此改为直接判断是否为变量。
2.  ApiService.php中，239行，加载关联时，由于此时的$articles返回paginate对象，因此不能使用数组方式判断是否为空(永远为空)，修改为调用items方法。